### PR TITLE
トーク中の波形の追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ao-talk",
+  "name": "ai-talk",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ao-talk",
+      "name": "ai-talk",
       "version": "0.1.0",
       "dependencies": {
         "@openai/realtime-api-beta": "github:openai/openai-realtime-api-beta",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ao-talk",
+  "name": "ai-talk",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,3 +25,21 @@ body {
     text-wrap: balance;
   }
 }
+
+.spinner {
+  border: 4px solid rgba(0, 0, 0, 0.2); /* 外側の薄い色 */
+  border-top: 4px solid #3498db; /* 回転する色 */
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ export default function Home() {
   // 音声を可視化するために波系
   const [waveformData, setWaveformData] = useState<number[]>([]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | null>(null);
 
   const drawWaveform = useCallback(() => {
     const canvas = canvasRef.current;
@@ -32,25 +33,37 @@ export default function Home() {
     if (!ctx) return;
 
     const { width, height } = canvas;
+    // Canvasのクリア
     ctx.clearRect(0, 0, width, height);
 
+    // 波形のスタイル設定
+    ctx.strokeStyle = "#ff6f6f"; // 背景色の補色
+    ctx.lineWidth = 4;
+
     // 波形を描画
-    ctx.strokeStyle = "#4A90E2"; // 青色の波形
-    ctx.lineWidth = 2;
     ctx.beginPath();
 
-    const sliceWidth = width / waveformData.length;
-    waveformData.forEach((value, index) => {
-      const x = sliceWidth * index;
-      const y = height / 2 + (value / 256) * (height / 2); // 値を高さにマッピング
-      if (index === 0) {
+    const centerY = height / 2; // 中央ライン
+    const step = Math.ceil(waveformData.length / canvas.width); // データの間引き
+    const amp = canvas.height / 2 - 10; // 波形の振幅（上下の最大高さ）
+
+    for (let x = 0; x < canvas.width; x++) {
+      const index = x * step;
+      const sample = waveformData[index] || 0; // 現在の音声データ
+      const y = centerY - (sample * amp) / 10; // 波の高さ
+
+      // 最初の点を moveTo、それ以降は lineTo
+      if (x === 0) {
         ctx.moveTo(x, y);
       } else {
         ctx.lineTo(x, y);
       }
-    });
+    }
 
     ctx.stroke();
+
+    // 次のフレームを描画
+    animationRef.current = requestAnimationFrame(drawWaveform);
   }, [waveformData]);
 
   const connectConversation = useCallback(async () => {
@@ -78,9 +91,10 @@ export default function Home() {
         client.appendInputAudio(data.mono);
 
         // 波形データを更新
-        const normalizedData = Array.from(data.mono, (sample) =>
-          Math.abs(sample * 128)
-        ); // 0-255に正規化
+        const normalizedData = Array.from(
+          data.mono,
+          (sample) => Math.abs(sample / 32768) // Normalize to range [0, 1]
+        );
         setWaveformData(normalizedData);
       });
     }
@@ -96,17 +110,31 @@ export default function Home() {
 
     wavStreamPlayer.interrupt();
 
-    setWaveformData([]); // 波形をリセット
+    // 波形を消去する処理
+    setWaveformData([]);
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+      }
+    }
   }, []);
 
   useEffect(() => {
     drawWaveform();
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
   }, [waveformData, drawWaveform]);
 
   useEffect(() => {
     // AIへの指示をセット
     client.updateSession({
-      instructions: "あなたは役にたつAIアシスタントです",
+      instructions:
+        "あなたは役にたつAIアシスタントです。ただ、しばしば質問者の意図を間違えることがあります。質問者の意図を汲み取れないことを考慮した上で、相手に不快感を与えずに会話をしてください。3回以上同じ回答をしそうな場合はあなたが上手く解釈できていない可能性があるため、相手に謝罪し話題を必ず変えてください。",
     });
     // 音声toテキスト翻訳のモデルをセット
     client.updateSession({ input_audio_transcription: { model: "whisper-1" } });
@@ -133,7 +161,13 @@ export default function Home() {
       console.log("convesation.updated");
       const items = client.conversation.getItems();
       console.log("items", items);
+      const audio: Int16Array = delta?.audio;
       if (delta?.audio) {
+        const normalizedData = Array.from(
+          audio,
+          (sample) => Math.abs(sample / 32768) // Normalize to range [0, 1]
+        );
+        setWaveformData(normalizedData);
         wavStreamPlayer.add16BitPCM(delta.audio, item.id);
       }
       if (item.status === "completed" && item.formatted.audio?.length) {
@@ -157,14 +191,25 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="relative bg-gray-100 min-h-screen flex flex-col items-center">
-      {/* 背景の波形 */}
+    <div
+      className="relative bg-gray-100 min-h-screen flex flex-col items-center"
+      style={{
+        background: "linear-gradient(to bottom, #a2d9ff, #d4f1ff)",
+      }}
+    >
+      {/* 背景中央に固定表示するCanvas */}
       <canvas
         ref={canvasRef}
-        className="absolute top-0 left-0 w-full h-full z-0"
         width={800}
         height={600}
-      />
+        style={{
+          position: "fixed",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          zIndex: 1, // 他のUIの上に表示
+        }}
+      ></canvas>
 
       <header className="bg-green-500 text-white w-full text-center py-4 z-10">
         <h1 className="text-xl font-bold">AO Talk</h1>
@@ -179,8 +224,8 @@ export default function Home() {
               key={item.id}
               className={`p-4 max-w-[80%] rounded-lg ${
                 item.role === "user"
-                  ? "bg-blue-500 text-white self-end"
-                  : "bg-gray-300 text-black self-start"
+                  ? "bg-green-500 text-black self-end"
+                  : "bg-white text-black self-start"
               }`}
             >
               <p>{item.formatted.transcript}</p>
@@ -201,7 +246,7 @@ export default function Home() {
             onClick={connectConversation}
             className="px-4 py-2 bg-green-500 text-white rounded-lg"
           >
-            録音開始
+            会話開始
           </button>
         )}
       </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -212,7 +212,7 @@ export default function Home() {
       ></canvas>
 
       <header className="bg-green-500 text-white w-full text-center py-4 z-10">
-        <h1 className="text-xl font-bold">AO Talk</h1>
+        <h1 className="text-xl font-bold">AI Talk</h1>
       </header>
       <main
         className="flex-1 w-full max-w-md mx-auto p-4 overflow-y-auto z-10"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -134,7 +134,7 @@ export default function Home() {
     // AIへの指示をセット
     client.updateSession({
       instructions:
-        "あなたは役にたつAIアシスタントです。ただ、しばしば質問者の意図を間違えることがあります。質問者の意図を汲み取れないことを考慮した上で、相手に不快感を与えずに会話をしてください。3回以上同じ回答をしそうな場合はあなたが上手く解釈できていない可能性があるため、相手に謝罪し話題を必ず変えてください。",
+        "あなたは役にたつAIアシスタントです。ただ、しばしば質問者の意図を間違えることがあります。違いますと言われたら回答するのをやめ、もう一度何を質問されたか聞き直してください。3回以上同じ回答をしそうな場合はあなたが上手く解釈できていない可能性があるため、相手に謝罪し話題を必ず変えてください。",
     });
     // 音声toテキスト翻訳のモデルをセット
     client.updateSession({ input_audio_transcription: { model: "whisper-1" } });
@@ -228,7 +228,17 @@ export default function Home() {
                   : "bg-white text-black self-start"
               }`}
             >
-              <p>{item.formatted.transcript}</p>
+              {item.formatted.transcript !== "" ? (
+                // テキスト表示
+                <p>{item.formatted.transcript}</p>
+              ) : item.formatted.text !== "" ? (
+                <p>{item.formatted.text}</p>
+              ) : (
+                // ローディングアイコン表示
+                <div className="flex items-center justify-center">
+                  <div className="spinner"></div>
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## linearタスク
https://linear.app/00quanta/issue/CC-252/ai%E3%83%88%E3%83%BC%E3%82%AF-%E9%9F%B3%E5%A3%B0%E3%81%AE%E8%A6%96%E8%A6%9A%E5%8C%96

## 対応内容
- トーク中に話者がしゃべった後に波が出るようにする
- 空文字の時にローディングアイコン出すようにする
- LINEライクな背景
![image](https://github.com/user-attachments/assets/ac149953-4542-4a59-a16a-736913baaf2e)
